### PR TITLE
fix(packaging): ship the device-capability KB inside the wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,13 @@ graft netadmin/_webui
 # Numbered SQL migrations applied at store startup — runtime data, must ship.
 recursive-include netadmin/store/migrations *.sql
 
+# Device-capability KB read by netadmin/detect/device_kb.py. Also declared in
+# pyproject.toml [tool.setuptools.package-data]; stated here too for the same
+# reason the migrations are: an install that silently loses this file still
+# starts, and the only symptom is detectors quietly running with no device
+# knowledge base.
+recursive-include netadmin/data *.json
+
 include README.md
 include LICENSE
 include requirements.txt

--- a/README.md
+++ b/README.md
@@ -398,9 +398,10 @@ explains why and what the frontend needs first.
 
 ## Configuration
 
-Two files under `data/`, both read at runtime, neither ever committed. `data/` is
-resolved relative to the directory you run the daemon from (so a `pip install` picks
-up the files you create next to it, and the database persists across upgrades). To
+Three files under `data/`, all read at runtime, none ever committed — the third
+optional. `data/` is resolved relative to the directory you run the daemon from
+(so a `pip install` picks up the files you create next to it, and the database
+persists across upgrades). To
 pin a fixed location — under systemd, or a shared data volume — set
 `NETADMIN_DATA_DIR=/path/to/data`.
 
@@ -429,6 +430,13 @@ pin a fixed location — under systemd, or a shared data volume — set
     wan_plan_down_mbps: null       # set your plan rate to enable WAN saturation
     wan_plan_up_mbps: null         # and bufferbloat detection (null = those detectors abstain)
   ```
+
+- **`data/wifi_device_capabilities.json`** (optional) overrides the device-capability
+  database — the pattern list that lets the detectors tell a 2.4-GHz-only IoT chip
+  from a coverage fault. A baseline ships inside the package, so the detectors work
+  without this file; create it only to add your own device patterns, and
+  `pip install --upgrade` will leave it untouched. See
+  [`docs/DEVICE_DATABASE.md`](docs/DEVICE_DATABASE.md).
 
 Environment variables override YAML: `DB_PATH`, `LOG_LEVEL`, `SITE_ID`,
 `SERVER_HOST`, `SERVER_PORT` map directly to the field names (no prefix).
@@ -603,7 +611,10 @@ path is exercised against mocks and dry-run rendering only.
 - [`docs/BACKUP.md`](docs/BACKUP.md): backing up and restoring the database.
 - [`SECURITY.md`](SECURITY.md): credential handling and the safety model.
 - [`docs/DEVICE_DATABASE.md`](docs/DEVICE_DATABASE.md): the device-capability
-  database.
+  database that tells 2.4-GHz-only IoT chips from coverage faults. Ships with the
+  package, so it works out of the box; drop your own
+  `data/wifi_device_capabilities.json` next to `secrets.env` to extend it and
+  upgrades will leave it alone.
 
 ---
 

--- a/docs/DEVICE_DATABASE.md
+++ b/docs/DEVICE_DATABASE.md
@@ -2,30 +2,80 @@
 
 ## Overview
 
-The WiFi device capability database (`wifi_device_capabilities.json`) is an external configuration file that defines which devices support which WiFi standards. This allows for easy updates without modifying code.
+The WiFi device capability database (`wifi_device_capabilities.json`) defines which devices support which WiFi standards. A baseline ships with the package; you can override it with your own copy, so devices can be added without modifying code.
 
 ## Location
+
+A baseline copy ships inside the package, so every install — wheel, container, or
+source checkout — has a working database with nothing to set up:
+
+```
+netadmin/data/wifi_device_capabilities.json
+```
+
+To customise it, put your own copy in the runtime data directory (the same one
+holding `secrets.env` and the database). It replaces the baseline wholesale:
 
 ```
 data/wifi_device_capabilities.json
 ```
 
+Resolution order:
+
+1. `thresholds['client.known_pathology']['kb_path']` in `data/config.yaml` — an
+   explicit path, if you want the file somewhere else entirely. **Used as-is: if
+   that file is missing or invalid it does *not* fall back to the paths below**,
+   because quietly reading a different file than you named would be worse. It
+   also applies to `client.known_pathology` only — the wired bad-cable detector
+   always resolves through 2 and 3, so setting it splits the two readers.
+2. `<data dir>/wifi_device_capabilities.json` — your copy. The data directory is
+   `NETADMIN_DATA_DIR` when set, otherwise `./data` relative to the working
+   directory the daemon was started from (under systemd, `WorkingDirectory=`).
+3. The packaged baseline above.
+
+With no `kb_path` set, the loader takes the first of 2 and 3 that exists. On a
+successful load the daemon logs one line naming the file and which tier it came
+from — the quickest way to confirm your copy is the one being read.
+
+Because your copy lives in the data directory, `pip install --upgrade` never
+touches it. Copy the packaged file to start from the shipped baseline:
+
+```bash
+mkdir -p data && cp "$(python -c 'import netadmin.detect.device_kb as k; print(k.PACKAGED_KB_PATH)')" data/
+```
+
 ## Purpose
 
-The analyzer uses this database to detect:
-- **WiFi 7 (802.11be)** devices: 6GHz capable with 320MHz channels and MLO
-- **WiFi 6E (802.11ax-6e)** devices: 6GHz capable with 160MHz channels
-- **Dual-band (WiFi 5/6)** devices: 2.4GHz + 5GHz capable
-- **2.4GHz-only** devices: IoT/smart home devices that should not be flagged
+> **Only `known_2.4ghz_only` currently drives detection.** The `wifi7_devices`,
+> `wifi6e_devices` and `dual_band_devices` sections are reserved — no code reads
+> them yet, so adding patterns there has no effect on what the daemon reports.
+> They are kept because the classification is useful reference and the sections
+> are expected to gain consumers.
+
+The `known_2.4ghz_only` list drives two detectors:
+
+- **`client.known_pathology`** fires a P3 `iot_pmf_11r` finding when a device in
+  this class disconnects repeatedly — the pattern of a 2.4-GHz-only chip that is
+  PMF / 802.11r intolerant, rather than a coverage problem.
+- **`wired.bad_cable`** uses the same list to *suppress* a speed-downshift
+  finding: a gigabit port sitting at 100 Mbps to one of these devices is the
+  device's design, not a broken pair.
+
+The device classes:
+- **WiFi 7 (802.11be)** devices: 6GHz capable with 320MHz channels and MLO *(reserved)*
+- **WiFi 6E (802.11ax-6e)** devices: 6GHz capable with 160MHz channels *(reserved)*
+- **Dual-band (WiFi 5/6)** devices: 2.4GHz + 5GHz capable *(reserved)*
+- **2.4GHz-only** devices: IoT/smart home devices — the one section read today
 
 ## Adding New Devices
 
 ### Quick Start
 
-To add a new device, simply edit `data/wifi_device_capabilities.json` and add the device name pattern to the appropriate section:
+To add a new device, edit your copy at `data/wifi_device_capabilities.json` (see
+[Location](#location)) and add the device name pattern to the appropriate section:
 
 **For a new WiFi 7 device:**
-```json
+```
 "wifi7_devices": {
   "patterns": [
     "iphone 16",
@@ -36,7 +86,7 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 ```
 
 **For a new WiFi 6E device:**
-```json
+```
 "wifi6e_devices": {
   "patterns": [
     "iphone 13",
@@ -48,18 +98,30 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 
 ### Pattern Matching Rules
 
-1. **Case-Insensitive**: Patterns are matched without regard to case
-   - Pattern: `"iphone 16"` matches `"iPhone-16-Pro"`, `"IPHONE 16"`, etc.
+Matching is a plain case-insensitive substring test against the client name (as
+the controller reports it) plus the OUI. That is all it is — there is no
+normalization and no regex.
 
-2. **Punctuation Normalization**: Hyphens, underscores, and extra spaces are normalized
-   - Pattern: `"galaxy s24"` matches `"Galaxy-S24"`, `"Galaxy_S24"`, `"Galaxy  S24"`, etc.
+1. **Case-Insensitive**: patterns and the name are both lowercased
+   - `"echo dot"` matches `"Kitchen-Echo Dot"` and `"ECHO DOT 3"`
 
-3. **Substring Matching**: Patterns match anywhere in the hostname
-   - Pattern: `"iphone 16"` matches `"Johns-iPhone-16-Pro"`, `"iPhone-16"`, `"Work-iPhone-16-Max"`, etc.
+2. **No punctuation normalization**: hyphens and underscores are *not* treated as
+   spaces. This is the mistake that costs people the most time
+   - ✅ `"iphone"` matches `"Johns-iPhone-16-Pro"`
+   - ❌ `"iphone 16"` does **not** match `"Johns-iPhone-16-Pro"` — the hostname
+     separates those words with a hyphen, not a space
+   - Prefer single-word patterns, or match the punctuation your controller
+     actually reports
 
-4. **Order Matters**: More specific patterns should come first
-   - ✅ Good: WiFi 7 → WiFi 6E → Dual-band → 2.4GHz-only
-   - ❌ Bad: Generic "galaxy" before specific "galaxy s24 ultra"
+3. **Substring Matching**: a pattern matches anywhere in the name
+   - `"esp32"` matches `"Garage-ESP32-sensor"`
+
+4. **Order does not matter**: sections are read independently and there is no
+   cross-section precedence. Keep patterns specific enough not to over-match
+   within their own section
+
+5. **No empty patterns**: an empty string would match every device, so blank
+   entries are discarded on load
 
 ### Best Practices
 
@@ -68,7 +130,8 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 - Use spaces (not hyphens) in patterns
 - Be specific for newer devices (`"iphone 16"`, `"galaxy s24 ultra"`)
 - Be generic for older device families (`"iphone"`, `"galaxy"`)
-- Add comments for clarity (use `"_comment"` fields or inline comments in arrays)
+- Add comments for clarity using `"_comment"` fields — JSON has no inline
+  comment syntax, and a `//` or `#` anywhere makes the whole file unparseable
 
 **❌ DON'T:**
 - Use overly generic patterns in WiFi 7/6E sections (will match too many devices)
@@ -79,7 +142,7 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 ### Examples
 
 **Adding a New WiFi 7 Phone:**
-```json
+```
 "wifi7_devices": {
   "patterns": [
     "iphone 16",
@@ -91,7 +154,7 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 ```
 
 **Adding a New WiFi 6E Laptop:**
-```json
+```
 "wifi6e_devices": {
   "patterns": [
     "macbook pro 2024",
@@ -103,7 +166,7 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 ```
 
 **Adding IoT Devices (2.4GHz-only):**
-```json
+```
 "known_2.4ghz_only": {
   "patterns": [
     "ring doorbell",
@@ -119,17 +182,29 @@ To add a new device, simply edit `data/wifi_device_capabilities.json` and add th
 After updating the device database, validate your changes:
 
 ```bash
-# Run validation tests
-python tests/test_wifi7_validation.py
-
-# Check that patterns are loading correctly
+# Confirm which file is being read, and that it parses
 python -c "
-from core.advanced_analyzer import AdvancedNetworkAnalyzer
-analyzer = AdvancedNetworkAnalyzer(client=None)
-print('WiFi 7 devices:', len(analyzer.device_capabilities['wifi7_devices']['patterns']))
-print('WiFi 6E devices:', len(analyzer.device_capabilities['wifi6e_devices']['patterns']))
-print('Patterns:', analyzer.device_capabilities['wifi7_devices']['patterns'][:10])
+from netadmin.detect import device_kb
+print('reading:', device_kb.default_kb_path())
+kb = device_kb.load_kb()
+print('parsed OK' if kb is not None else 'NOT LOADED - check JSON syntax and path')
+for section in ('wifi7_devices', 'wifi6e_devices', 'known_2.4ghz_only'):
+    print(section, len(device_kb.section_patterns(kb, section)), 'patterns')
 "
+```
+
+Run it from the same working directory the daemon uses, so `./data` resolves the
+same way. If `reading:` prints a path ending in `netadmin/data/` — whether under
+`site-packages` or inside a source checkout — your own copy was not found and the
+packaged baseline is in use.
+
+A section reporting `0 patterns` when you have entries in it means that section is
+the wrong shape. Each one must be an object with a `patterns` list — a bare list
+(`"known_2.4ghz_only": ["esp32"]`) or a bare string (`"patterns": "esp32"`) is
+ignored:
+
+```json
+"known_2.4ghz_only": { "patterns": ["esp32", "tuya"] }
 ```
 
 ## Database Structure
@@ -138,10 +213,10 @@ print('Patterns:', analyzer.device_capabilities['wifi7_devices']['patterns'][:10
 
 | Section | Purpose | Example Patterns |
 |---------|---------|------------------|
-| `wifi7_devices` | WiFi 7 (802.11be) capable - 6GHz + 320MHz + MLO | `iphone 16`, `galaxy s25` |
-| `wifi6e_devices` | WiFi 6E (802.11ax-6e) capable - 6GHz + 160MHz | `iphone 14`, `pixel 7` |
-| `dual_band_devices` | Dual-band (2.4/5 GHz) capable - WiFi 5/6 | `iphone`, `galaxy`, `macbook` |
-| `known_2.4ghz_only` | 2.4GHz-only devices - don't flag as misplaced | `ring doorbell`, `echo dot` |
+| `wifi7_devices` | WiFi 7 (802.11be) capable - 6GHz + 320MHz + MLO *(reserved, unread)* | `iphone 16`, `galaxy s25` |
+| `wifi6e_devices` | WiFi 6E (802.11ax-6e) capable - 6GHz + 160MHz *(reserved, unread)* | `iphone 14`, `pixel 7` |
+| `dual_band_devices` | Dual-band (2.4/5 GHz) capable - WiFi 5/6 *(reserved, unread)* | `iphone`, `galaxy`, `macbook` |
+| `known_2.4ghz_only` | 2.4GHz-only devices - fires `iot_pmf_11r` on repeat disconnects, and suppresses `wired.bad_cable` downshifts | `ring doorbell`, `echo dot` |
 
 ### Metadata Fields
 
@@ -188,17 +263,27 @@ print('Patterns:', analyzer.device_capabilities['wifi7_devices']['patterns'][:10
 
 ## Real-World Example
 
-**Scenario**: You just bought an iPhone 16 Pro Max and it's showing as "5GHz capable" instead of "WiFi 7 capable" in your network analysis.
+**Scenario**: a 2.4-GHz-only smart plug keeps dropping off the network. The
+daemon reports the disconnects but never explains them, because the plug is not
+in the database — so `client.known_pathology` cannot tell a chip limitation from
+a coverage problem, and no `iot_pmf_11r` finding is raised.
 
 **Solution**:
-1. Open `data/wifi_device_capabilities.json`
-2. Find the `wifi7_devices` section
-3. Check if `"iphone 16"` is in the patterns list (it should be)
-4. If not, add it: `"iphone 16 pro max"` or just `"iphone 16"`
+1. Find the name the controller shows for it, e.g. `Laundry-Tasmota-Plug`
+2. Open your copy at `data/wifi_device_capabilities.json` (see [Location](#location))
+3. Find the `known_2.4ghz_only` section
+4. Add a pattern that appears in that name: `"tasmota"`
 5. Save the file
-6. Re-run the analysis: `python optimize_network.py analyze`
+6. Restart the daemon so the detectors reload the database
 
-The pattern `"iphone 16"` will match all variants: iPhone 16, iPhone 16 Plus, iPhone 16 Pro, iPhone 16 Pro Max.
+After the next WINDOW pass the repeat disconnects are attributed as
+`iot_pmf_11r` (a 2.4-GHz-only device likely PMF / 802.11r intolerant) rather than
+left unexplained. The same entry stops a gigabit switch port that negotiates 100
+Mbps to that plug from being reported as a bad cable.
+
+Note `"tasmota"` is a single word on purpose. `"tasmota plug"` would **not**
+match `Laundry-Tasmota-Plug`, because the hostname uses hyphens and no
+normalization happens.
 
 ## Troubleshooting
 
@@ -207,15 +292,18 @@ The pattern `"iphone 16"` will match all variants: iPhone 16, iPhone 16 Plus, iP
 **Problem**: Your device shows as "Unknown" or wrong capability level.
 
 **Solutions**:
-1. Check hostname format: Run analysis with `--verbose` to see actual hostnames
+1. Check the hostname the controller actually reports — patterns match the client
+   name as UniFi sees it, which is often not the name on the device itself
 2. Add pattern: Ensure pattern is in correct section and lowercase
 3. Check priority: More specific patterns should be in higher-priority sections (WiFi 7 before dual-band)
 4. Test matching:
    ```python
-   from core.advanced_analyzer import AdvancedNetworkAnalyzer
-   analyzer = AdvancedNetworkAnalyzer(client=None)
-   result = analyzer._check_device_pattern("Your-Device-Name", ["your pattern"])
-   print(f"Match result: {result}")
+   from netadmin.detect import device_kb
+   kb = device_kb.load_kb()
+   name = "Your-Device-Name".lower()
+   for section in ("wifi7_devices", "wifi6e_devices", "dual_band_devices", "known_2.4ghz_only"):
+       hits = [p for p in device_kb.section_patterns(kb, section) if p in name]
+       print(section, "->", hits)
    ```
 
 ### Pattern Not Loading
@@ -223,10 +311,17 @@ The pattern `"iphone 16"` will match all variants: iPhone 16, iPhone 16 Plus, iP
 **Problem**: Changes to JSON file not taking effect.
 
 **Solutions**:
-1. Check JSON syntax: Validate at https://jsonlint.com
-2. Check file location: Must be in `data/wifi_device_capabilities.json`
-3. Restart analysis: Python caches imports, restart your analysis script
-4. Check permissions: Ensure file is readable
+1. Check which file is actually being read: run the snippet under
+   [Testing Changes](#testing-changes). If it prints a `site-packages` path, your
+   copy is not where the loader looks — see [Location](#location).
+2. Check the data directory: your copy must be at
+   `<data dir>/wifi_device_capabilities.json`, where the data directory is
+   `NETADMIN_DATA_DIR` if set, else `./data` relative to the daemon's working
+   directory (for systemd, that is `WorkingDirectory=`).
+3. Check JSON syntax: a malformed file is skipped, and the daemon logs
+   `known_pathology: could not load device KB at ...; running KB-empty`.
+4. Restart the daemon: the database is cached in-process.
+5. Check permissions: ensure the file is readable by the daemon's user.
 
 ### False Positives
 

--- a/netadmin/data/wifi_device_capabilities.json
+++ b/netadmin/data/wifi_device_capabilities.json
@@ -1,7 +1,7 @@
 {
-    "_comment": "WiFi device capability database - defines which devices support which WiFi standards",
+    "_comment": "WiFi device capability database - device-name patterns grouped by class. Only known_2.4ghz_only currently drives detection; the other sections are reserved.",
     "_last_updated": "2025-01-05",
-    "_instructions": "Add device name patterns (case-insensitive, partial match). Patterns are checked in order, most specific first.",
+    "_instructions": "Add device name patterns as lowercase substrings of the client name as the controller reports it. Matching is plain case-insensitive substring, so 'iphone 16' does NOT match 'iPhone-16-Pro' (hyphens are not normalized).",
     "wifi7_devices": {
         "_description": "WiFi 7 (802.11be) capable devices - support 2.4/5/6 GHz with 320MHz channels and MLO",
         "_standards": [
@@ -166,10 +166,11 @@
     },
     "_version": "1.0.0",
     "_schema_notes": {
-        "pattern_matching": "All patterns are converted to lowercase and spaces/hyphens are normalized for flexible matching",
-        "priority_order": "Patterns are checked in order: WiFi 7 → WiFi 6E → Dual-band → 2.4GHz-only",
-        "partial_match": "Patterns use substring matching, so 'iphone 16' matches 'iPhone-16-Pro', 'Johns-iPhone-16', etc.",
-        "updating": "To add new devices, simply append to the appropriate patterns array. No code changes needed.",
-        "testing": "After updates, run: python tests/test_wifi7_validation.py"
+        "pattern_matching": "Patterns are lowercased and matched as plain substrings against the lowercased client name plus OUI. No normalization of spaces or hyphens.",
+        "priority_order": "Reserved for future use. Only known_2.4ghz_only is read today, so no cross-section ordering applies.",
+        "partial_match": "Substring matching: 'iphone' matches 'Johns-iPhone-16-Pro', but 'iphone 16' does not, because the hostname separates the words with hyphens.",
+        "updating": "Append to the appropriate patterns array. No code changes needed.",
+        "shape": "Each section must be an object with a 'patterns' list of non-empty strings. A bare list, a string 'patterns' value, or an empty string is ignored.",
+        "testing": "After updates: python -c \"from netadmin.detect import device_kb; kb=device_kb.load_kb(); print(device_kb.default_kb_path()); print(len(device_kb.section_patterns(kb,'known_2.4ghz_only')),'patterns')\""
     }
 }

--- a/netadmin/detect/detectors/client.py
+++ b/netadmin/detect/detectors/client.py
@@ -14,7 +14,8 @@ infrastructure:
   grace period. Severity scales with breadth: a single client is P3, a
   site-wide DHCP failure (many clients at once) is P1.
 * :class:`KnownPathologyDetector` (``client.known_pathology``) — a device-class
-  knowledge base (``data/wifi_device_capabilities.json``) plus a small built-in
+  knowledge base (``wifi_device_capabilities.json``, located by
+  :mod:`netadmin.detect.device_kb`) plus a small built-in
   symptom table: a 2.4-GHz-only IoT chip that disconnects (PMF / 802.11r
   intolerance), or an Apple client roam-scanning near its −70 dBm trigger.
 
@@ -27,9 +28,10 @@ so a client keeps one stable issue identity as its attribution is refined.
 from __future__ import annotations
 
 import json
-from pathlib import Path
+import time
 from typing import Any, Iterable, Optional
 
+from netadmin.detect import device_kb
 from netadmin.detect.engine import COVERAGE_MIN, UNKNOWN, EvalResult
 from netadmin.domain.entities import Entity, Finding
 from netadmin.domain.types import Cadence, EntityType, Severity
@@ -55,10 +57,10 @@ DEFAULT_DISCONNECT_KEYS: tuple[str, ...] = ("EVT_WU_Disconnected", "EVT_LU_Disco
 # APIPA / link-local self-assigned prefix: a client showing this got no DHCP lease.
 _APIPA_PREFIX = "169.254."
 
-# Default location of the device-capability KB, resolved relative to the repo root
-# (netadmin/detect/detectors/client.py -> parents[3] == repo root). Overridable via
-# ``settings.thresholds['client.known_pathology']['kb_path']``.
-_DEFAULT_KB_PATH = Path(__file__).resolve().parents[3] / "data" / "wifi_device_capabilities.json"
+# A KB that cannot be read is re-reported at most this often. The load is retried
+# every pass (a corrupt or half-written file is usually transient), but one line
+# per pass on a WINDOW-cadence detector would drown the log.
+_KB_REWARN_S = 3600.0
 
 
 # --------------------------------------------------------------------------- #
@@ -436,6 +438,7 @@ class KnownPathologyDetector:
     def __init__(self) -> None:
         self._kb: Optional[dict[str, Any]] = None
         self._kb_path_loaded: Optional[str] = None
+        self._kb_warned_at: Optional[float] = None
 
     def evaluate(self, ctx: Any) -> EvalResult:
         window_s = int(ctx.threshold(self.key, "window_s", 3600))
@@ -471,7 +474,7 @@ class KnownPathologyDetector:
         haystack = f"{name} {oui}"
 
         # --- IoT 2.4-only + disconnects -> PMF/11r intolerance ---
-        if _matches_patterns(haystack, kb.get("known_2.4ghz_only", {}).get("patterns", [])):
+        if _matches_patterns(haystack, device_kb.section_patterns(kb, "known_2.4ghz_only")):
             disconnects = len(
                 ctx.events(
                     entity_id=client.entity_id,
@@ -526,19 +529,41 @@ class KnownPathologyDetector:
         return None
 
     def _load_kb(self, ctx: Any) -> dict[str, Any]:
-        path = str(ctx.threshold(self.key, "kb_path", str(_DEFAULT_KB_PATH)))
+        """The device KB, cached per resolved path; ``{}`` when it cannot be read.
+
+        A configured ``kb_path`` is used verbatim: it does NOT fall back to the
+        data-dir or packaged copies, because silently reading a different file
+        than the operator named would be worse than running KB-empty. An empty
+        or unset value falls through to :func:`device_kb.default_kb_path`.
+
+        Only a *successful* load is cached. A failure is retried on the next
+        pass and re-reported every :data:`_KB_REWARN_S`, so a transient unreadable
+        file (a half-written save, a mount blip) recovers on its own rather than
+        disabling the ``iot_pmf_11r`` branch until the daemon restarts.
+        """
+        override = ctx.threshold(self.key, "kb_path", None)
+        path = str(override) if override else str(device_kb.default_kb_path())
         if self._kb is not None and self._kb_path_loaded == path:
             return self._kb
-        kb: dict[str, Any] = {}
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                loaded = json.load(fh)
-            if isinstance(loaded, dict):
-                kb = loaded
-        except (OSError, ValueError):
-            _log.warning("known_pathology: could not load device KB at %s; running KB-empty", path)
+
+        kb = device_kb.load_kb(path)
+        if kb is None:
+            now = time.monotonic()
+            if self._kb_warned_at is None or now - self._kb_warned_at >= _KB_REWARN_S:
+                self._kb_warned_at = now
+                _log.warning(
+                    "known_pathology: device KB at %s is missing or unparseable, so the "
+                    "iot_pmf_11r branch is disabled. Fix the JSON, or remove the file "
+                    "(and any kb_path override) to fall back to the packaged baseline "
+                    "at %s.",
+                    path,
+                    device_kb.PACKAGED_KB_PATH,
+                )
+            return {}  # not cached: retried next pass
+
         self._kb = kb
         self._kb_path_loaded = path
+        self._kb_warned_at = None
         return kb
 
 

--- a/netadmin/detect/detectors/wired.py
+++ b/netadmin/detect/detectors/wired.py
@@ -37,11 +37,10 @@ not yet persist) rather than fabricate a finding.
 
 from __future__ import annotations
 
-import json
-import os
 from functools import lru_cache
 from typing import Any, Iterable, Optional
 
+from netadmin.detect import device_kb
 from netadmin.detect.baseline import hour_label
 from netadmin.detect.engine import COVERAGE_MIN, UNKNOWN, EvalResult
 from netadmin.domain.entities import Entity, Finding
@@ -64,7 +63,7 @@ _COVERAGE_JOB = "fast_device"
 # Device-name / OUI substrings whose peers commonly negotiate 10/100 by design, so
 # a gigabit-capable switch port sitting at 100 Mbps to one of them is NOT a
 # broken-pair downshift. Seeded with common wired IoT/legacy classes and augmented
-# best-effort from data/wifi_device_capabilities.json's known-2.4GHz-only list
+# best-effort from wifi_device_capabilities.json's known-2.4GHz-only list
 # (those classes — smart plugs, ESP modules, legacy consoles — are the same
 # fast-ethernet-at-best population).
 _KNOWN_100MBPS_HINTS: tuple[str, ...] = (
@@ -103,28 +102,30 @@ _KNOWN_100MBPS_HINTS: tuple[str, ...] = (
 def _known_100mbps_patterns() -> tuple[str, ...]:
     """Built-in 10/100 device hints plus the capabilities-file 2.4GHz-only list.
 
-    Loaded once, best-effort: the file lives at the repo's
-    ``data/wifi_device_capabilities.json`` but this module never depends on the
-    cwd, so a missing/unparseable file simply yields the built-in list. The
-    2.4GHz-only classes there (ESP modules, smart plugs, legacy consoles) overlap
-    the wired fast-ethernet population, so they are a usable supplementary hint.
+    Loaded once, best-effort, via :mod:`netadmin.detect.device_kb`: a missing or
+    unparseable KB simply yields the built-in list. The 2.4GHz-only classes there
+    (ESP modules, smart plugs, legacy consoles) overlap the wired fast-ethernet
+    population, so they are a usable supplementary hint.
+
+    This reads the default KB location only. The ``client.known_pathology``
+    ``kb_path`` override does not apply here: the result is process-cached and
+    this helper has no DetectorContext to read thresholds from.
+
+    A failure is worth one line now that a baseline always ships inside the
+    package: it means the operator's copy is corrupt or the install is damaged,
+    neither of which is routine. ``client.known_pathology`` cannot be relied on
+    to report it -- it returns UNKNOWN on low coverage before ever loading the
+    KB, and under a ``kb_path`` override it reads a different file entirely.
     """
     patterns = list(_KNOWN_100MBPS_HINTS)
-    path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "..",
-        "..",
-        "data",
-        "wifi_device_capabilities.json",
-    )
-    try:
-        with open(os.path.normpath(path), "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        extra = data.get("known_2.4ghz_only", {}).get("patterns", [])
-        patterns.extend(str(p).lower() for p in extra)
-    except (OSError, ValueError, AttributeError):
-        pass  # built-in hints are enough; the file is an optional enrichment
+    kb = device_kb.load_kb()
+    if kb is None:
+        _log.warning(
+            "bad_cable: device KB at %s is missing or unparseable; falling back to "
+            "built-in 10/100 hints only",
+            device_kb.default_kb_path(),
+        )
+    patterns.extend(device_kb.section_patterns(kb, "known_2.4ghz_only"))
     return tuple(dict.fromkeys(patterns))  # de-dup, order-stable
 
 

--- a/netadmin/detect/device_kb.py
+++ b/netadmin/detect/device_kb.py
@@ -1,0 +1,135 @@
+"""Locating and loading the device-capability knowledge base.
+
+The KB (``wifi_device_capabilities.json``) maps device-name patterns to device
+classes. Only ``known_2.4ghz_only`` currently drives detection, at two call
+sites: :class:`~netadmin.detect.detectors.client.KnownPathologyDetector` fires
+``iot_pmf_11r`` when a device in that class disconnects repeatedly, and the wired
+bad-cable detector reuses the same list to suppress a downshift finding against a
+peer that negotiates 10/100 by design. The ``wifi7_devices`` / ``wifi6e_devices``
+/ ``dual_band_devices`` sections are reserved -- no code reads them yet.
+
+Resolution order (first hit wins):
+
+1. ``settings.thresholds['client.known_pathology']['kb_path']`` -- an explicit
+   operator override, applied by the caller rather than here, because only the
+   detector holds a :class:`~netadmin.detect.context.DetectorContext` to read
+   thresholds from. It therefore reaches ``client.known_pathology`` only; the
+   wired detector always resolves through tiers 2-3.
+2. ``<data dir>/wifi_device_capabilities.json`` -- the operator's own editable
+   copy in the runtime data dir (``NETADMIN_DATA_DIR``, else ``./data``). This
+   is what makes the KB user-extensible per docs/DEVICE_DATABASE.md without
+   editing anything inside site-packages, and puts it where ``pip install
+   --upgrade`` cannot clobber it.
+3. :data:`PACKAGED_KB_PATH` -- the baseline shipped inside the wheel.
+
+Step 3 is why this module exists. The KB used to be resolved as
+``Path(__file__).parents[3] / "data" / ...``, which is the repo root from a
+source checkout but ``site-packages/data/`` once installed -- a directory that
+never exists -- so *every* wheel install silently ran KB-empty. That is the same
+class of bug as the ``DATA_DIR`` fix in 0.1.2 (resolve runtime paths from the
+runtime, shipped assets from the package), applied to the one asset that fix
+missed. The one-line INFO on first successful load exists so the *next* bug of
+this class is one ``grep`` away instead of invisible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from netadmin import config
+from netadmin.logging import get_logger
+
+__all__ = [
+    "KB_FILENAME",
+    "PACKAGED_KB_PATH",
+    "default_kb_path",
+    "load_kb",
+    "section_patterns",
+]
+
+_log = get_logger("detect.device_kb")
+
+KB_FILENAME = "wifi_device_capabilities.json"
+
+# The baseline copy shipped inside the package. netadmin/detect/device_kb.py ->
+# parents[1] == the netadmin package root, so this is netadmin/data/<file>, which
+# pyproject's package-data glob ("data/*.json") puts in the wheel.
+PACKAGED_KB_PATH = Path(__file__).resolve().parents[1] / "data" / KB_FILENAME
+
+# Paths already announced at INFO, so a per-pass detector does not re-log a state
+# that cannot change without a restart. Failures are deliberately NOT tracked
+# here: callers re-announce those on their own schedule, because a load that
+# fails today may succeed tomorrow and must not be silenced after one line.
+_announced_paths: set[str] = set()
+
+
+def default_kb_path() -> Path:
+    """The KB to read when no explicit ``kb_path`` override is configured.
+
+    Prefers the operator's editable copy in the runtime data dir and falls back
+    to the packaged baseline, so a wheel install always has a real KB to read.
+
+    ``config.DATA_DIR`` is read here rather than captured at import so tests can
+    monkeypatch it (and so the value tracks the module attribute, which
+    :mod:`netadmin.config` computes from ``Path.cwd()`` at *its* import).
+    """
+    operator_copy = config.DATA_DIR / KB_FILENAME
+    return operator_copy if operator_copy.is_file() else PACKAGED_KB_PATH
+
+
+def load_kb(path: Optional[Union[str, Path]] = None) -> Optional[dict[str, Any]]:
+    """Load the KB mapping from ``path`` (default: :func:`default_kb_path`).
+
+    Returns ``None`` on failure -- the file is missing, unreadable, not valid
+    JSON, or not a JSON object -- so callers can tell "no KB at all" from a KB
+    that parsed fine and happens to be empty, and log accordingly. Logging the
+    failure is left to callers, who know whether it is expected and how often to
+    repeat it; a successful load announces its path once per process.
+    """
+    target = Path(path) if path is not None else default_kb_path()
+    try:
+        with open(target, "r", encoding="utf-8") as fh:
+            loaded = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+
+    key = str(target)
+    if key not in _announced_paths:
+        _announced_paths.add(key)
+        _log.info(
+            "device KB: reading %s (%s); %d known-2.4GHz-only patterns",
+            target,
+            "packaged baseline" if target == PACKAGED_KB_PATH else "operator copy",
+            len(section_patterns(loaded, "known_2.4ghz_only")),
+        )
+    return loaded
+
+
+def section_patterns(kb: Optional[dict[str, Any]], section: str) -> tuple[str, ...]:
+    """Lowercased, de-duplicated patterns for ``section``; ``()`` for any bad shape.
+
+    The KB is hand-edited JSON, so every level below "it parsed" is untrusted.
+    Read sections through here rather than chasing ``kb[section]["patterns"]``
+    inline: the expected shape is ``{"patterns": [str, ...]}``, and the three
+    shapes an operator most plausibly writes instead are all traps.
+
+    A bare list (``"known_2.4ghz_only": ["esp32"]``) makes the inline chase raise
+    ``AttributeError`` on ``list.get``; the detection engine isolates the raising
+    detector and skips it, so a small typo silently takes a whole detector
+    offline. A bare string (``"patterns": "esp32"``) is worse: it is iterable, so
+    substring matching walks it character by character and ``"e"`` matches nearly
+    every device name, inventing findings. An empty string among the patterns is
+    worse still -- ``"" in haystack`` is always true, so it matches *everything*,
+    which in the wired detector suppresses every bad-cable finding on the site.
+    All three collapse to a safe value here.
+    """
+    block = (kb or {}).get(section)
+    raw = block.get("patterns") if isinstance(block, dict) else None
+    if not isinstance(raw, list):
+        return ()
+    cleaned = (str(p).strip().lower() for p in raw)
+    return tuple(dict.fromkeys(p for p in cleaned if p))  # de-dup, order-stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,13 @@ namespaces = false
 include-package-data = true
 
 [tool.setuptools.package-data]
-# The prebuilt web UI (no Node needed at runtime) AND the numbered SQL migrations
-# the store applies at startup via netadmin/store/db.py:MIGRATIONS_DIR — both are
-# non-.py runtime data that must ship inside the wheel or `netadmin` cannot boot.
-netadmin = ["_webui/**/*", "store/migrations/*.sql"]
+# The prebuilt web UI (no Node needed at runtime), the numbered SQL migrations
+# the store applies at startup via netadmin/store/db.py:MIGRATIONS_DIR, AND the
+# device-capability KB located by netadmin/detect/device_kb.py — all non-.py
+# runtime data that must ship inside the wheel. Without the first two `netadmin`
+# cannot boot; without the third the known_pathology and bad-cable detectors
+# silently run with no device knowledge base.
+netadmin = ["_webui/**/*", "store/migrations/*.sql", "data/*.json"]
 
 [tool.black]
 line-length = 100

--- a/tests/netadmin/detect/detectors/test_client.py
+++ b/tests/netadmin/detect/detectors/test_client.py
@@ -6,8 +6,14 @@ case, and an UNKNOWN-coverage case.
 
 from __future__ import annotations
 
+import json
+import logging
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from netadmin import config
 from netadmin.detect.context import DetectorContext
 from netadmin.detect.detectors.client import (
     KEY_DHCP,
@@ -24,6 +30,19 @@ from netadmin.store.repository import Repository, SampleReading
 from tests.netadmin.detect.support import FakeBaselines, seed_coverage
 
 NOW = 4_000_000
+
+
+@pytest.fixture(autouse=True)
+def _pin_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep KB resolution off the developer's real ``./data``.
+
+    ``config.DATA_DIR`` is ``Path.cwd() / "data"``, and docs/DEVICE_DATABASE.md now
+    tells operators to put their own ``wifi_device_capabilities.json`` there. Without
+    this, anyone who follows that advice on their dev box gets unrelated failures in
+    the known_pathology tests. Pinning it at an empty tmp dir also makes "no override"
+    mean the *packaged baseline*, specifically.
+    """
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "data")
 
 
 def _ctx(repo: Repository, *, settings=None, now: int = NOW) -> DetectorContext:
@@ -266,3 +285,117 @@ def test_known_pathology_threshold_override(repo: Repository) -> None:
     )
     findings = KnownPathologyDetector().evaluate(_ctx(repo, settings=settings))
     assert len(findings) == 1
+
+
+def _iot_client_with_disconnects(repo: Repository, *, mac: str, name: str) -> None:
+    seed_coverage(repo, job="fast_sta", now=NOW, window_s=3600, interval_s=60)
+    ap = _ap(repo, "ap-1")
+    cid = _client(repo, mac=mac, name=name, ap_id=ap)
+    for k in range(4):
+        _disconnect(repo, cid, ap, NOW - 100 - k * 10, reason=15)
+
+
+def test_known_pathology_kb_path_override_is_honoured(repo: Repository, tmp_path: Path) -> None:
+    """An explicit kb_path outranks the default location.
+
+    The device name matches nothing in the shipped KB, so a finding here can only
+    come from the override actually being read.
+    """
+    custom_kb = tmp_path / "custom_kb.json"
+    custom_kb.write_text(json.dumps({"known_2.4ghz_only": {"patterns": ["widgetron"]}}))
+    _iot_client_with_disconnects(repo, mac="io:5", name="Widgetron-9000")
+
+    settings = SimpleNamespace(
+        thresholds={KEY_KNOWN_PATHOLOGY: {"kb_path": str(custom_kb)}}, poll=None
+    )
+    findings = KnownPathologyDetector().evaluate(_ctx(repo, settings=settings))
+    assert len(findings) == 1
+    assert findings[0].evidence["pathology"] == "iot_pmf_11r"
+
+
+def test_known_pathology_degrades_quietly_when_the_kb_is_missing(
+    repo: Repository, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """KB-empty must return no findings rather than raise -- but must SAY so.
+
+    The iot_pmf_11r branch is driven entirely by the KB's known_2.4ghz_only list,
+    so with no KB it goes quiet. That silence is the whole bug this commit fixes,
+    so the warning is the early-warning system and is asserted, not assumed.
+    """
+    _iot_client_with_disconnects(repo, mac="io:6", name="ESP32-sensor")
+    missing = tmp_path / "absent.json"
+
+    settings = SimpleNamespace(
+        thresholds={KEY_KNOWN_PATHOLOGY: {"kb_path": str(missing)}}, poll=None
+    )
+    with caplog.at_level(logging.WARNING):
+        assert KnownPathologyDetector().evaluate(_ctx(repo, settings=settings)) == []
+
+    assert str(missing) in caplog.text
+    # The remediation matters: a typo'd kb_path otherwise leaves no way to know
+    # a working baseline exists.
+    assert "packaged baseline" in caplog.text
+
+
+def test_known_pathology_retries_a_failed_kb_instead_of_caching_it(
+    repo: Repository, tmp_path: Path
+) -> None:
+    """A KB that fails once must not disable the branch until the daemon restarts.
+
+    The daemon runs for months; a half-written save or a mount blip would
+    otherwise poison the detector permanently, reporting "no IoT pathologies"
+    with total confidence.
+    """
+    kb_path = tmp_path / "later.json"
+    _iot_client_with_disconnects(repo, mac="io:a", name="ESP32-sensor")
+    settings = SimpleNamespace(
+        thresholds={KEY_KNOWN_PATHOLOGY: {"kb_path": str(kb_path)}}, poll=None
+    )
+    detector = KnownPathologyDetector()
+    assert detector.evaluate(_ctx(repo, settings=settings)) == []  # nothing there yet
+
+    kb_path.write_text(json.dumps({"known_2.4ghz_only": {"patterns": ["esp32"]}}))
+    findings = detector.evaluate(_ctx(repo, settings=settings))
+    assert len(findings) == 1, "the same detector instance must pick up the repaired KB"
+
+
+def test_known_pathology_survives_a_malformed_kb_section(repo: Repository, tmp_path: Path) -> None:
+    """A hand-edited section of the wrong shape must not take the detector offline.
+
+    ``{"known_2.4ghz_only": [...]}`` (a bare list rather than an object with a
+    ``patterns`` key) used to raise AttributeError on ``list.get``; the engine
+    isolates a raising detector, so one typo cost the whole pass.
+    """
+    broken_kb = tmp_path / "broken_kb.json"
+    broken_kb.write_text(json.dumps({"known_2.4ghz_only": ["esp32", "tuya"]}))
+    _iot_client_with_disconnects(repo, mac="io:8", name="ESP32-sensor")
+
+    settings = SimpleNamespace(
+        thresholds={KEY_KNOWN_PATHOLOGY: {"kb_path": str(broken_kb)}}, poll=None
+    )
+    assert KnownPathologyDetector().evaluate(_ctx(repo, settings=settings)) == []
+
+
+def test_known_pathology_ignores_string_valued_patterns(repo: Repository, tmp_path: Path) -> None:
+    """A string is iterable: 'e' would otherwise match nearly every device name."""
+    broken_kb = tmp_path / "string_patterns.json"
+    broken_kb.write_text(json.dumps({"known_2.4ghz_only": {"patterns": "esp32"}}))
+    _iot_client_with_disconnects(repo, mac="io:9", name="Johns-MacBook-Pro")
+
+    settings = SimpleNamespace(
+        thresholds={KEY_KNOWN_PATHOLOGY: {"kb_path": str(broken_kb)}}, poll=None
+    )
+    assert KnownPathologyDetector().evaluate(_ctx(repo, settings=settings)) == []
+
+
+def test_known_pathology_finds_the_default_kb_with_no_override(repo: Repository) -> None:
+    """The counterpart: with no kb_path configured, the shipped KB must be found.
+
+    This is the regression guard -- an ESP32 fires only if the default resolution
+    landed on a real KB file.
+    """
+    _iot_client_with_disconnects(repo, mac="io:7", name="ESP32-sensor")
+
+    findings = KnownPathologyDetector().evaluate(_ctx(repo))
+    assert len(findings) == 1
+    assert findings[0].evidence["device_class"] == "known_2.4ghz_only"

--- a/tests/netadmin/detect/detectors/test_wired.py
+++ b/tests/netadmin/detect/detectors/test_wired.py
@@ -9,12 +9,19 @@ driven deterministically without spinning the whole EWMA engine.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
+import pytest
+
+from netadmin import config
+from netadmin.detect import device_kb
 from netadmin.detect.baseline import Band
 from netadmin.detect.context import DetectorContext
 from netadmin.detect.detectors.wired import (
+    _KNOWN_100MBPS_HINTS,
     KEY_BAD_CABLE,
     KEY_BROADCAST_STORM,
     KEY_DUPLEX_MISMATCH,
@@ -31,6 +38,7 @@ from netadmin.detect.detectors.wired import (
     SfpDegradedDetector,
     StpLoopDetector,
     UplinkSaturationDetector,
+    _known_100mbps_patterns,
 )
 from netadmin.detect.engine import UNKNOWN
 from netadmin.domain.entities import Entity
@@ -795,3 +803,96 @@ def test_thresholds_are_overridable(repo: Repository) -> None:
     settings = SimpleNamespace(thresholds={KEY_BAD_CABLE: {"errors_per_min": 3.0}}, poll=None)
     findings = BadCableDetector().evaluate(_ctx(repo, settings=settings))
     assert len(findings) == 1
+
+
+# ====================================================================== #
+# the device-KB half of the 10/100 hint list
+# ====================================================================== #
+# _known_100mbps_patterns is lru_cached, so a test that resolves the KB under a
+# patched DATA_DIR would otherwise poison every later test in the session.
+@pytest.fixture(autouse=True)
+def _clear_pattern_cache():
+    _known_100mbps_patterns.cache_clear()
+    yield
+    _known_100mbps_patterns.cache_clear()
+
+
+def _write_kb(data_dir: Path, payload: dict) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / device_kb.KB_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_patterns_absorb_the_kb_2_4ghz_only_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The KB half of the hint list -- the symptom no wheel install ever had.
+
+    The existing suppression tests use names ("ESP32", "Sure Petcare") that the
+    built-in tuple already covers, so they pass with the KB contributing nothing.
+    """
+    data_dir = tmp_path / "data"
+    _write_kb(data_dir, {"known_2.4ghz_only": {"patterns": ["Widgetron", "ESP32"]}})
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+
+    patterns = _known_100mbps_patterns()
+    assert "widgetron" in patterns  # KB enriches...
+    assert "petcare" in patterns  # ...without displacing the built-ins
+    assert patterns.count("esp32") == 1  # overlap de-dupes
+
+
+def test_patterns_fall_back_to_builtins_when_no_kb_is_readable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "absent")
+    monkeypatch.setattr(device_kb, "PACKAGED_KB_PATH", tmp_path / "also-absent.json")
+    assert _known_100mbps_patterns() == _KNOWN_100MBPS_HINTS
+
+
+@pytest.mark.parametrize(
+    "section",
+    [["esp32"], {"patterns": "esp32"}, {"patterns": None}, "esp32"],
+    ids=["bare-list", "string-patterns", "null-patterns", "bare-string"],
+)
+def test_patterns_ignore_a_malformed_kb_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, section
+) -> None:
+    """A hand-edit of the wrong shape must not disturb the built-in list."""
+    data_dir = tmp_path / "data"
+    _write_kb(data_dir, {"known_2.4ghz_only": section})
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+    assert _known_100mbps_patterns() == _KNOWN_100MBPS_HINTS
+
+
+def test_an_empty_kb_pattern_cannot_match_everything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``"" in haystack`` is always True.
+
+    One stray empty string -- valid JSON, easy to leave behind in a hand-edit --
+    would otherwise make every entity look like a by-design 10/100 peer and
+    suppress every bad_cable finding on the site, silently.
+    """
+    data_dir = tmp_path / "data"
+    _write_kb(data_dir, {"known_2.4ghz_only": {"patterns": ["esp32", "", "   "]}})
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+    assert "" not in _known_100mbps_patterns()
+
+
+def test_bad_cable_suppression_can_come_from_the_kb_alone(
+    repo: Repository, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a peer matched only by a KB pattern still suppresses the finding.
+
+    "widgetron" is in no built-in hint, so this fires only if the KB actually
+    reached the detector -- the user-visible behaviour the packaging bug removed.
+    """
+    data_dir = tmp_path / "data"
+    _write_kb(data_dir, {"known_2.4ghz_only": {"patterns": ["widgetron"]}})
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+
+    full_coverage(repo)
+    sw = make_switch(repo)
+    pid = make_port(repo, sw_id=sw, idx=1, meta={"max_speed": 1000}, speed=100)
+    make_client(repo, sw_id=sw, name="Widgetron-9000")
+    seed_counter(repo, pid, "rx_errors", step=0)
+    assert BadCableDetector().evaluate(_ctx(repo)) == []

--- a/tests/netadmin/detect/test_device_kb.py
+++ b/tests/netadmin/detect/test_device_kb.py
@@ -1,0 +1,177 @@
+"""Locating the device-capability KB (:mod:`netadmin.detect.device_kb`).
+
+The regression these guard: the KB used to be resolved relative to the *source
+tree* (``parents[3]/data``), which is ``site-packages/data`` on a wheel install --
+a directory that never exists -- so every pip install ran with no device knowledge
+base at all, silently. The load path must therefore work with no repo checkout and
+no particular working directory, and the baseline copy must live inside the
+package so pyproject's package-data glob actually ships it.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from netadmin import config
+from netadmin.detect import device_kb
+
+PACKAGE_ROOT = Path(config.__file__).resolve().parent
+PYPROJECT = PACKAGE_ROOT.parent / "pyproject.toml"
+
+
+# --------------------------------------------------------------------------- #
+# the packaged baseline
+# --------------------------------------------------------------------------- #
+def test_packaged_kb_ships_inside_the_netadmin_package() -> None:
+    """The baseline must sit under netadmin/ or package-data cannot ship it."""
+    assert device_kb.PACKAGED_KB_PATH.is_file()
+    assert device_kb.PACKAGED_KB_PATH.is_relative_to(PACKAGE_ROOT)
+    assert device_kb.PACKAGED_KB_PATH.parent == PACKAGE_ROOT / "data"
+    assert device_kb.PACKAGED_KB_PATH.suffix == ".json"
+
+
+@pytest.mark.skipif(not PYPROJECT.is_file(), reason="source checkout only")
+def test_package_data_glob_actually_covers_the_packaged_kb() -> None:
+    """Putting the KB inside the package is only half the fix; it must be declared.
+
+    The original bug was not a missing file -- the repo's ``data/`` directory was
+    there all along. What never existed was the packaging declaration, so the
+    wheel shipped without it. Asserting only the file's location leaves that half
+    unguarded: drop ``data/*.json`` from package-data and every other test here
+    still passes while the wheel silently loses the file again.
+    """
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    globs = pyproject["tool"]["setuptools"]["package-data"]["netadmin"]
+    relative = PurePosixPath(device_kb.PACKAGED_KB_PATH.relative_to(PACKAGE_ROOT).as_posix())
+    assert any(
+        relative.match(glob) for glob in globs
+    ), f"{relative} matches none of {globs}; it will not ship in the wheel"
+
+
+def test_packaged_kb_is_a_usable_capability_database() -> None:
+    """A shipped-but-malformed KB would be as useless as a missing one."""
+    kb = device_kb.load_kb(device_kb.PACKAGED_KB_PATH)
+    assert kb is not None
+    # The sections the two detector call sites actually read.
+    assert isinstance(kb.get("known_2.4ghz_only", {}).get("patterns"), list)
+    assert kb["known_2.4ghz_only"]["patterns"], "2.4GHz-only list drives both detectors"
+
+
+# --------------------------------------------------------------------------- #
+# resolution order
+# --------------------------------------------------------------------------- #
+def test_default_path_falls_back_to_packaged_copy_when_data_dir_has_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "data")
+    assert device_kb.default_kb_path() == device_kb.PACKAGED_KB_PATH
+
+
+def test_default_path_prefers_the_operators_copy_in_the_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """docs/DEVICE_DATABASE.md promises an editable copy; it must win."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    operator_copy = data_dir / device_kb.KB_FILENAME
+    operator_copy.write_text(json.dumps({"wifi7_devices": {"patterns": ["my device"]}}))
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+
+    assert device_kb.default_kb_path() == operator_copy
+    assert device_kb.load_kb()["wifi7_devices"]["patterns"] == ["my device"]
+
+
+def test_resolution_survives_a_data_dir_that_does_not_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wheel-install regression: no checkout, no ./data, still a real KB.
+
+    ``DATA_DIR`` here points at a directory that was never created, which is what
+    a daemon started outside its data dir sees. The old resolution returned
+    ``site-packages/data/...`` and simply did not exist; this must still land on a
+    readable file.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path / "definitely-absent")
+
+    resolved = device_kb.default_kb_path()
+    assert resolved == device_kb.PACKAGED_KB_PATH
+    assert resolved.is_file(), "a wheel install must still find a KB"
+    assert device_kb.load_kb() is not None
+
+
+def test_a_directory_at_the_operator_path_is_not_mistaken_for_a_kb(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``is_file()`` guards the tier-2 probe, so a stray directory falls through."""
+    data_dir = tmp_path / "data"
+    (data_dir / device_kb.KB_FILENAME).mkdir(parents=True)
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+
+    assert device_kb.default_kb_path() == device_kb.PACKAGED_KB_PATH
+
+
+# --------------------------------------------------------------------------- #
+# load_kb failure modes -- None, never a silently-empty dict
+# --------------------------------------------------------------------------- #
+def test_load_returns_none_for_a_missing_file(tmp_path: Path) -> None:
+    assert device_kb.load_kb(tmp_path / "absent.json") is None
+
+
+def test_load_returns_none_for_unparseable_json(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert device_kb.load_kb(bad) is None
+
+
+@pytest.mark.parametrize("payload", ["[1, 2]", '"a string"', "null"])
+def test_load_returns_none_when_the_json_is_not_an_object(tmp_path: Path, payload: str) -> None:
+    """A JSON array parses fine but has no sections; that is 'no KB', not 'empty KB'."""
+    path = tmp_path / "wrong_shape.json"
+    path.write_text(payload)
+    assert device_kb.load_kb(path) is None
+
+
+def test_load_distinguishes_no_kb_from_an_empty_one(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.json"
+    empty.write_text("{}")
+    assert device_kb.load_kb(empty) == {}  # a real, empty KB
+    assert device_kb.load_kb(tmp_path / "gone.json") is None  # no KB at all
+
+
+# --------------------------------------------------------------------------- #
+# section_patterns -- the KB is hand-edited, so section shape is untrusted
+# --------------------------------------------------------------------------- #
+def test_section_patterns_reads_the_expected_shape() -> None:
+    kb = {"known_2.4ghz_only": {"patterns": ["ESP32", " Tuya "]}}
+    assert device_kb.section_patterns(kb, "known_2.4ghz_only") == ("esp32", "tuya")
+
+
+def test_section_patterns_survives_a_bare_list_section() -> None:
+    """The trap that took the detector offline: ``list.get`` raises AttributeError.
+
+    The engine isolates a raising detector and skips it, so this typo used to cost
+    the whole of client.known_pathology for the pass.
+    """
+    kb = {"known_2.4ghz_only": ["esp32", "tuya"]}
+    assert device_kb.section_patterns(kb, "known_2.4ghz_only") == ()
+
+
+def test_section_patterns_rejects_a_bare_string_patterns_value() -> None:
+    """The worse trap: a string is iterable, so 'e' would match nearly every name."""
+    kb = {"known_2.4ghz_only": {"patterns": "esp32"}}
+    assert device_kb.section_patterns(kb, "known_2.4ghz_only") == ()
+
+
+@pytest.mark.parametrize("kb", [None, {}, {"other_section": {"patterns": ["x"]}}])
+def test_section_patterns_returns_empty_for_absent_sections(kb) -> None:
+    assert device_kb.section_patterns(kb, "known_2.4ghz_only") == ()
+
+
+def test_section_patterns_drops_blank_entries_and_de_dupes() -> None:
+    kb = {"known_2.4ghz_only": {"patterns": ["esp32", "", "  ", "ESP32", "tuya"]}}
+    assert device_kb.section_patterns(kb, "known_2.4ghz_only") == ("esp32", "tuya")


### PR DESCRIPTION
## The bug

`wifi_device_capabilities.json` never shipped in the wheel. It lived at the repo root in `data/`, and `client.py` resolved it as `Path(__file__).parents[3] / "data" / ...` — the repo root from a source checkout, but `site-packages/data/` once installed, a directory that never exists. `[tool.setuptools.package-data]` listed only `_webui` and `store/migrations`.

So **every pip and container install ran with no device knowledge base**, and both readers degraded silently:

- **`client.known_pathology`** — the `iot_pmf_11r` branch is driven *entirely* by the KB's `known_2.4ghz_only` patterns (`client.py:474`), with no hardcoded fallback. That pathology was **dead on every wheel install**, not degraded. The Apple roam branch survived only because its patterns are inline. The one trace was a single `running KB-empty` line at startup.
- **`wired.bad_cable`** — lost its supplementary fast-ethernet hints and quietly fell back to the built-in tuple.

Same class as `4c69292` (resolve runtime paths from the runtime, shipped assets from the package), applied to the asset that fix missed.

Reproduced on `main`: building a wheel from a pristine `upstream/main` export yields **zero** entries under `netadmin/data/`, while its own suite is green (291 passed) — the bug shipped without a failing test.

## The fix

Move the baseline to `netadmin/data/` so package-data can ship it, and add `netadmin/detect/device_kb.py` as the single place that locates it:

1. `thresholds['client.known_pathology']['kb_path']` — explicit, **used as-is** (no fallback, deliberately: silently reading a file the operator didn't name is worse)
2. `<data dir>/wifi_device_capabilities.json` — the operator's editable copy
3. the packaged baseline

Tier 2 keeps `docs/DEVICE_DATABASE.md`'s promise that the KB is user-editable, and puts that copy where `pip install --upgrade` can't clobber it. `wired.py` now shares the resolver instead of hand-rolling `../../../data`.

### Hardening

The KB is hand-edited JSON the docs actively invite operators to copy, so `section_patterns()` replaces the inline `kb[section]["patterns"]` chase at both call sites. The three shapes an operator plausibly writes instead were all traps:

| Operator writes | Old behaviour |
|---|---|
| `"known_2.4ghz_only": ["esp32"]` | `AttributeError` on `list.get` → engine firewall skips the **whole detector**, every pass |
| `"patterns": "esp32"` | string is iterable → substring match walks it char by char, `"e"` matches nearly every device name → **invented findings** |
| `"patterns": ["esp32", ""]` | `"" in haystack` is always true → matches **everything** → suppresses every `bad_cable` finding on the site |

All three now collapse to a safe value.

### Observability

A failed load is no longer cached. It was memoized as `{}` and warned exactly once, so a transient unreadable file (half-written save, mount blip) disabled `iot_pmf_11r` until restart while still reporting "no IoT pathologies" confidently. Failures now retry each pass, re-warn hourly, and name the packaged baseline so a typo'd `kb_path` has a way back. One INFO line on first successful load names the file and tier — the observability whose absence is why this survived.

## Docs

Corrected against the code, not restated. The shipped JSON claimed hyphens are normalized and that `"iphone 16"` matches `"iPhone-16-Pro"` (both false — matching is plain substring), described a cross-section priority order that doesn't exist, and pointed at `tests/test_wifi7_validation.py`, deleted in the rebuild. Since this PR makes that file ship to every user, those claims would have been distributed.

`docs/DEVICE_DATABASE.md` additionally said the loader falls back when `kb_path` is missing (it doesn't), omitted that `kb_path` reaches only one of the two readers, presented three sections no code reads as if they drive detection, recommended inline JSON comments (invalid JSON), and built its worked example on a WiFi-7 classification that doesn't exist.

## Verification

- Built wheel **and** sdist from a pristine export of this commit; KB present in both (survives the sdist→wheel round-trip `python -m build` uses)
- Installed that wheel into a clean venv, ran from a directory with no `data/`: tier 3 resolves, all 23 patterns load; tiers 1–2 take precedence; each malformed shape degrades safely — in the real install, not just under pytest
- **Mutation-tested** the new guards; each is caught by a failing test: revert the file move (6 failures), drop the package-data glob (1), remove the wired KB enrichment (2), un-harden the client call site (2), re-cache a failed load (1)
- Full suite **1822 passed**, coverage **92.16%** (gate 85%); black/isort/flake8 clean at the pinned CI versions

The pre-existing detector tests caught none of these — a source checkout resolved the old path fine, which is exactly why this shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
