### PR TITLE
fix(fixes): let the channel fix apply to auto-channel radios, safely

### DIFF
--- a/netadmin/fixes/applier.py
+++ b/netadmin/fixes/applier.py
@@ -353,7 +353,11 @@ class Applier:
             if live is None:
                 drifted.append(step)
                 continue
-            if any(live.get(k) != v for k, v in expected.items()):
+            # A key the live read could not produce is drift, not a match: an
+            # expected value of None (a radio_table entry with no channel key)
+            # must never be satisfied by the empty extract of a radio that has
+            # vanished from the device entirely.
+            if any(k not in live or live[k] != v for k, v in expected.items()):
                 drifted.append(step)
         return drifted
 

--- a/netadmin/fixes/planner.py
+++ b/netadmin/fixes/planner.py
@@ -264,7 +264,9 @@ def _plan_band_channel_spread(
     Every step is an ordinary, individually revertible ``rest/device`` PUT that
     preserves the rest of its device's ``radio_table``; the plan carries no new
     gate and no new capability. A radio whose live channel no longer matches the
-    evidence is dropped from the plan rather than moved on a stale assumption.
+    evidence is dropped from the plan rather than moved on a stale assumption --
+    a pinned radio by its configured channel, an auto radio by the operating
+    channel its device's stats report.
     """
     band = str(finding.evidence.get("band") or "")
     subtype = str(finding.evidence.get("subtype") or finding.dims.get("subtype") or "")
@@ -361,6 +363,12 @@ def _channel_step(
     dev_id, radio_table, radio = _locate_radio(device, band_code)
     if dev_id is None or radio is None:
         return None
+    if radio.get("channel") is None:
+        # No configured channel to assert means no precondition worth the name:
+        # {"channel": None} is the one expected value a VANISHED radio's empty
+        # live extract would satisfy, quietly defeating the missing-target drift
+        # guard on a device-mutating PUT. Refuse to plan instead.
+        return None
     live = _as_int(radio.get("channel"))
     if expect_channel is not None and live is not None and live != expect_channel:
         return None
@@ -385,10 +393,17 @@ def _channel_step(
         method="PUT",
         endpoint=endpoint,
         payload=payload,
+        # The precondition asserts the CONFIGURED channel -- the same
+        # ``radio_table`` field the applier's live read extracts -- not the
+        # operating channel the detector observed. On an auto-channel radio
+        # (UniFi's factory default) the two speak different languages: config
+        # says "auto" while the evidence says the int the radio happens to be
+        # on, and asserting the int against "auto" is a precondition no live
+        # read can satisfy. The plan then renders forever and applies never.
         precondition=Precondition(
             target_native_id=native_id,
-            expected={"channel": current},
-            description=f"Radio must still be on channel {current}.",
+            expected={"channel": radio.get("channel")},
+            description=(f"Radio channel must still be set to {radio.get('channel')}."),
         ),
         before={"method": "PUT", "endpoint": endpoint, "body": {"radio_table": list(radio_table)}},
         after={"method": "PUT", "endpoint": endpoint, "body": payload},
@@ -618,8 +633,14 @@ def _drifted_radios(
     """Conflicted radios whose live channel no longer matches the evidence.
 
     Only radios we actually hold a live device read for can be checked; one we
-    were not handed is left alone, because "unknown" is not "drifted". Returns
-    readable native ids so the advisory can name them.
+    were not handed is left alone, because "unknown" is not "drifted". A pinned
+    radio is compared on its configured channel; an auto radio has no configured
+    int to compare, so it is compared on the OPERATING channel the device's
+    ``radio_table_stats`` reports -- an auto radio that has hopped since
+    detection has invalidated the load vector exactly as a re-pinned one has,
+    and skipping it (the old behaviour) let a hopped auto radio sail into a
+    joint solve built on a band layout it already left. Returns readable native
+    ids so the advisory can name them.
     """
     out: list[str] = []
     for channel, natives in conflicted.items():
@@ -632,9 +653,24 @@ def _drifted_radios(
             if radio is None:
                 continue
             live = _as_int(radio.get("channel"))
+            if live is None:
+                live = _operating_channel(device, band_code)
             if live is not None and live != channel:
                 out.append(native_id)
     return sorted(out)
+
+
+def _operating_channel(device: Mapping[str, Any], band_code: Optional[str]) -> Optional[int]:
+    """The channel a radio is transmitting on, from ``radio_table_stats``.
+
+    The configured channel lives in ``radio_table`` and can be the string
+    "auto"; the stats table carries the int the auto planner actually chose.
+    ``None`` when the device does not report stats for the radio.
+    """
+    for entry in device.get("radio_table_stats") or []:
+        if isinstance(entry, Mapping) and entry.get("radio") == band_code:
+            return _as_int(entry.get("channel"))
+    return None
 
 
 def _channel_loads(evidence: Mapping[str, Any], candidates: tuple[int, ...]) -> dict[int, int]:

--- a/netadmin/fixes/service.py
+++ b/netadmin/fixes/service.py
@@ -101,6 +101,20 @@ class IssueNotFound(FixError):
     """The issue id does not exist (surfaces as a 404 / CLI error)."""
 
 
+class IssueNotActionable(FixError):
+    """The issue is no longer live, so applying its fix would act on stale state.
+
+    An issue's evidence is refreshed only while its detector FIRES; once the
+    condition stops, evidence freezes at its last-firing value while the network
+    keeps moving. Nothing else in the gate chain notices for an auto-channel
+    radio: config stays "auto", so the precondition passes and the confirm token
+    stays valid indefinitely. Refusing resolved/resolving issues bounds the apply
+    window to the life of the problem itself — a saved token for a self-resolved
+    issue must not pin a radio weeks later on evidence about a channel it left.
+    Dry-run stays open: previewing a stale plan is harmless and useful.
+    """
+
+
 @dataclass
 class FixSeams:
     """The injected controller seams a :class:`FixService` needs.
@@ -187,6 +201,17 @@ class FixService:
         min-RSSI rail before a single call is sent. Only an applied change records
         the ``fix_applied`` event that starts the section-7 verification window.
         """
+        row = self._store.get_issue(issue_id)
+        if row is None:
+            raise IssueNotFound(f"issue {issue_id} not found")
+        state = str(row["state"])
+        if state in ("resolving", "resolved"):
+            raise IssueNotActionable(
+                f"issue {issue_id} is {state}: its evidence is no longer live, so the "
+                "fix would apply against the network as it was, not as it is. If the "
+                "problem returns, the next detection pass re-raises it with fresh "
+                "evidence and a fresh plan."
+            )
         plan = await self.build_plan(issue_id)
         current_state = await self._read_current_state(plan)
         result = await self._applier.apply(

--- a/tests/netadmin/fixes/test_applier.py
+++ b/tests/netadmin/fixes/test_applier.py
@@ -504,3 +504,101 @@ async def test_apply_of_advisory_plan_is_noop(store):
     assert result.aborted_reason == "manual_action_required"
     assert writer.call_count == 0
     assert store.list_changes() == []
+
+
+# --------------------------------------------------------------------------- #
+# auto-channel radios go through the REAL gate
+# --------------------------------------------------------------------------- #
+def _auto_channel_plan(issue_id=None):
+    device = make_ap_device(radios=[{"radio": "ng", "channel": "auto", "ht": 20}])
+    finding = make_finding(
+        "wifi.channel_plan",
+        radio_entity("ng"),
+        dims={"subtype": "channel_off_grid", "band": "2.4"},
+        evidence={"subtype": "channel_off_grid", "band": "2.4", "channel": 3},
+    )
+    return plan_fix(finding, device=device, issue_id=issue_id), device
+
+
+async def test_auto_channel_plan_applies_through_the_real_gate(store):
+    """The shipped regression, end to end: an unchanged auto radio must APPLY.
+
+    Before the fix this exact call aborted with PreconditionDrift on every auto
+    radio (UniFi's factory default): the precondition asserted the operating
+    int from evidence against a live config that says "auto", forever.
+    """
+    from netadmin.fixes.service import _extract_target_attrs
+
+    writer = FakeControllerWriter()
+    applier = Applier(store, writer)
+    plan, device = _auto_channel_plan()
+    step = plan.steps[0]
+    live = _extract_target_attrs(
+        device, step.precondition.target_native_id, step.precondition.expected
+    )
+    result = await applier.apply(
+        plan,
+        dry_run=False,
+        confirm_token=plan_confirm_token(plan),
+        current_state={step.precondition.target_native_id: live},
+    )
+    assert result.applied is True
+    assert writer.call_count == 1
+
+
+async def test_auto_channel_plan_pinned_meanwhile_still_aborts(store):
+    """The guard keeps guarding: pin the radio between render and apply."""
+    from netadmin.fixes.service import _extract_target_attrs
+
+    writer = FakeControllerWriter()
+    applier = Applier(store, writer)
+    plan, _device = _auto_channel_plan()
+    step = plan.steps[0]
+    pinned = make_ap_device(radios=[{"radio": "ng", "channel": 6, "ht": 20}])
+    live = _extract_target_attrs(
+        pinned, step.precondition.target_native_id, step.precondition.expected
+    )
+    with pytest.raises(PreconditionDrift):
+        await applier.apply(
+            plan,
+            dry_run=False,
+            confirm_token=plan_confirm_token(plan),
+            current_state={step.precondition.target_native_id: live},
+        )
+    assert writer.call_count == 0
+
+
+async def test_vanished_radio_is_drift_even_when_expected_would_be_none(store):
+    """The empty extract of a gone radio must never satisfy any precondition.
+
+    Belt-and-braces with the planner's refusal to build a {"channel": None}
+    precondition: even a hand-forged plan carrying one aborts, because a key
+    the live read could not produce is drift, not a None == None match.
+    """
+    from netadmin.fixes.service import _extract_target_attrs
+
+    writer = FakeControllerWriter()
+    applier = Applier(store, writer)
+    plan, _device = _auto_channel_plan()
+    step = plan.steps[0]
+    step.precondition.expected = {"channel": None}  # forge the hole
+    vanished = make_ap_device(radios=[{"radio": "na", "channel": 36, "ht": 40}])
+    live = _extract_target_attrs(
+        vanished, step.precondition.target_native_id, step.precondition.expected
+    )
+    with pytest.raises(PreconditionDrift):
+        await applier.apply(
+            plan,
+            dry_run=False,
+            confirm_token=plan_confirm_token(plan),
+            current_state={step.precondition.target_native_id: live},
+        )
+    assert writer.call_count == 0
+
+
+async def test_auto_channel_revert_body_still_says_auto(store):
+    """What makes the fix revertible: the before-state carries "auto" verbatim."""
+    plan, _device = _auto_channel_plan()
+    step = plan.steps[0]
+    radios = {r["radio"]: r for r in step.before["body"]["radio_table"]}
+    assert radios["ng"]["channel"] == "auto"

--- a/tests/netadmin/fixes/test_planner.py
+++ b/tests/netadmin/fixes/test_planner.py
@@ -423,3 +423,110 @@ def test_band_replan_still_plans_when_the_live_layout_matches():
 
     assert len(plan.steps) == 1
     assert plan.manual_action_required is False
+
+
+# --------------------------------------------------------------------------- #
+# auto-channel radios: the plan must be appliable, not just renderable
+# --------------------------------------------------------------------------- #
+def test_auto_channel_radio_precondition_expects_auto():
+    """The precondition must assert the CONFIGURED channel, not the operating one.
+
+    Auto is UniFi's factory default. The detector's evidence carries the channel
+    the radio is operating on (an int); the device object's configured channel is
+    the string "auto". Asserting the operating int against the configured string
+    is a precondition no live read can ever satisfy: the plan renders, the apply
+    always aborts with drift, and the fix is dead on arrival for every
+    default-configured radio — which is how it shipped.
+    """
+    device = make_ap_device(radios=[{"radio": "ng", "channel": "auto", "ht": 20}])
+    finding = make_finding(
+        "wifi.channel_plan",
+        radio_entity("ng"),
+        dims={"subtype": "channel_off_grid", "band": "2.4"},
+        evidence={"subtype": "channel_off_grid", "band": "2.4", "channel": 3},
+    )
+    plan = plan_fix(finding, device=device)
+    step = plan.steps[0]
+    assert step.action is ActionType.CHANNEL_CHANGE
+    assert step.precondition.expected == {"channel": "auto"}
+
+
+def test_auto_channel_radio_with_no_channel_key_is_not_planned():
+    """A radio_table entry with no channel at all yields an advisory, not a step.
+
+    ``{"channel": None}`` is the one expected value a VANISHED radio's empty live
+    extract would satisfy — planning on it would quietly defeat the
+    missing-target drift guard on a device-mutating PUT.
+    """
+    device = make_ap_device(radios=[{"radio": "ng", "ht": 20}])
+    finding = make_finding(
+        "wifi.channel_plan",
+        radio_entity("ng"),
+        dims={"subtype": "channel_off_grid", "band": "2.4"},
+        evidence={"subtype": "channel_off_grid", "band": "2.4", "channel": 3},
+    )
+    plan = plan_fix(finding, device=device)
+    assert plan.steps == []
+    assert plan.manual_action_required
+
+
+def test_band_replan_drops_an_auto_radio_that_hopped_since_detection():
+    """An auto radio is drift-checked on its OPERATING channel from stats.
+
+    Config "auto" never changes, so the configured-channel comparison is blind
+    to a hop; skipping auto radios (the old behaviour) let a joint solve run
+    against a band layout the radio had already left.
+    """
+    natives = [f"aa:bb:cc:00:00:0{i}:ng" for i in (1, 2)]
+    finding = _band_finding([(1, natives)], per_channel={"1": 2, "6": 0, "11": 0})
+    devices = {}
+    for i, native in enumerate(sorted(natives)):
+        mac = native.rsplit(":", 1)[0]
+        devices[mac] = make_ap_device(
+            device_id=f"dev{i}",
+            mac=mac,
+            radios=[{"radio": "ng", "channel": "auto", "ht": 20}],
+        )
+        # dev0 hopped to 6 since detection; dev1 still operates on 1.
+        devices[mac]["radio_table_stats"] = [{"radio": "ng", "channel": 6 if i == 0 else 1}]
+
+    plan = plan_fix(finding, devices=devices)
+    assert plan.steps == []
+    assert plan.manual_action_required
+
+
+def test_band_replan_of_unhopped_auto_radios_renders_and_survives_the_live_read():
+    """The factory-default fleet case: all-auto radios, none hopped, plan applies.
+
+    This is the joint-path twin of the single-radio regression test — the
+    multi-AP scenario is where the unsatisfiable precondition actually bit.
+    """
+    from netadmin.fixes.applier import Applier
+    from netadmin.fixes.service import _extract_target_attrs
+
+    natives = [f"aa:bb:cc:00:00:0{i}:ng" for i in (1, 2)]
+    finding = _band_finding([(1, natives)], per_channel={"1": 2, "6": 0, "11": 0})
+    devices = {}
+    for i, native in enumerate(sorted(natives)):
+        mac = native.rsplit(":", 1)[0]
+        devices[mac] = make_ap_device(
+            device_id=f"dev{i}",
+            mac=mac,
+            radios=[{"radio": "ng", "channel": "auto", "ht": 20}],
+        )
+        devices[mac]["radio_table_stats"] = [{"radio": "ng", "channel": 1}]
+
+    plan = plan_fix(finding, devices=devices)
+    assert len(plan.steps) == 1  # one radio moves off the shared channel
+    step = plan.steps[0]
+    assert step.precondition.expected == {"channel": "auto"}
+
+    mac = step.precondition.target_native_id.rsplit(":", 1)[0]
+    live = _extract_target_attrs(
+        devices[mac], step.precondition.target_native_id, step.precondition.expected
+    )
+    # State-free check; instantiating a full Applier here would add nothing.
+    drifted = Applier.__new__(Applier)._precondition_drift(
+        plan, {step.precondition.target_native_id: live}
+    )
+    assert drifted == []

--- a/tests/netadmin/fixes/test_service.py
+++ b/tests/netadmin/fixes/test_service.py
@@ -531,3 +531,38 @@ async def test_partial_apply_still_arms_verification(store):
     v = svc.verification(issue_id)
     assert v.status is VerificationStatus.PENDING, "a partial apply must still arm"
     assert v.armed_ts == NOW
+
+
+# --------------------------------------------------------------------------- #
+# a fix only applies while its issue is live
+# --------------------------------------------------------------------------- #
+async def test_apply_refuses_a_resolving_or_resolved_issue(store):
+    """A saved confirm token must not outlive the problem it was minted for.
+
+    Evidence refreshes only while the detector fires; once the issue clears it
+    freezes while the network keeps moving. On an auto-channel radio nothing
+    else in the chain notices — config stays "auto", the precondition passes,
+    and the token stays valid indefinitely. The state gate bounds the apply
+    window to the life of the problem: a self-resolved issue's fix is refused,
+    and the next detection pass re-raises with fresh evidence if it returns.
+    """
+    from netadmin.fixes.service import IssueNotActionable
+
+    issue_id = _seed_channel_plan_issue(store)
+    writer = FakeControllerWriter()
+    svc = _service(store, writer=writer)
+    dry = await svc.dry_run(issue_id)  # preview stays open regardless of state
+
+    for state in ("resolving", "resolved"):
+        store._conn.execute("UPDATE issues SET state=? WHERE id=?", (state, issue_id))
+        store._conn.commit()
+        with pytest.raises(IssueNotActionable):
+            await svc.apply(issue_id, confirm_token=dry.confirm_token)
+        assert writer.call_count == 0
+
+    # A live issue still applies with the very same token.
+    store._conn.execute("UPDATE issues SET state='active' WHERE id=?", (issue_id,))
+    store._conn.commit()
+    result = await svc.apply(issue_id, confirm_token=dry.confirm_token)
+    assert result.applied is True
+    assert writer.call_count == 1


### PR DESCRIPTION
## The bug

`netadmin fix <id>` for a `wifi.channel_plan` issue renders a correct plan, then `--apply --confirm` aborts with **"drifted from expected state" — every time, with nothing changing on the device between the two commands.** Found applying a real plan on a real site: dry-run clean, apply aborted, twice, same token.

The precondition asserted the **operating** channel against the **configured** one. `_channel_step` built `expected={"channel": <int from evidence>}`; the applier's live read extracts `radio_table[].channel`, which on an auto-channel radio is the string `"auto"` — and **auto is UniFi's factory default**. `_coerce_like("auto", 1)` can't equate them, so the fix was dead on arrival for most real sites. The planner's own plan-time guard agreed with neither side: `_as_int("auto")` → `None` → "unknown, proceed".

## The fix

The precondition now asserts the same field the live read extracts — the configured channel, verbatim (`"auto"` or a pinned int). An unchanged device satisfies its own precondition by construction; a radio pinned between render and apply still drifts and aborts.

## What making it satisfiable exposed

The unsatisfiable precondition had been (vacuously) protecting three real holes. This PR closes the set rather than trading one silence for another:

1. **A resolved/resolving issue now refuses to apply.** Evidence refreshes only while the detector fires; once the issue clears it freezes while the network keeps moving. On an auto radio nothing else notices — config stays `"auto"`, the confirm token (hash of method+endpoint+payload, no TTL) stays valid indefinitely. A saved token for a self-resolved issue could pin a radio weeks later on evidence about a channel it left. Dry-run stays open — previewing is harmless.
2. **Auto radios in a joint band re-plan are drift-checked on their *operating* channel** from `radio_table_stats`. The plan-time guard used to skip them entirely (`_as_int("auto")` → skip), so a hopped auto radio sailed into a joint solve built on a band layout it had already left — exactly the "can make the spread worse" hazard the module's own comment warns about. The apply path rebuilds the plan, so this guard runs there too.
3. **A radio entry with no `channel` key is refused rather than planned.** `{"channel": None}` is the one expected value a *vanished* radio's empty live extract would satisfy — quietly defeating the missing-target drift guard on a device-mutating PUT. Belt-and-braces, the applier now treats a key the live read couldn't produce as drift (the guarantee its docstring already claimed), so even a hand-forged `None` precondition aborts.

## Tests

Every guard is individually mutation-pinned — reverting the precondition source, removing the state gate, reverting missing-key-is-drift, removing the None-channel refusal, and removing the stats hop-check each fail exactly one targeted test. The regression pair runs through the **real** `Applier` gate (`writer.call_count == 1` on the happy path, `0` on drift), and the joint band path — the multi-AP factory-default case where this actually bit — has its own render-and-survive-the-live-read test. The revert `before`-body carrying `"auto"` verbatim is asserted, which is what makes the fix reversible.

Full suite 1927 passed, coverage 92.36% (gate 85%); black/isort/flake8 clean at the pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
