### PR TITLE
fix(wifi): read neighbour scan strength as dBm, not the raw quality index

### DIFF
--- a/netadmin/detect/detectors/wifi.py
+++ b/netadmin/detect/detectors/wifi.py
@@ -1866,6 +1866,70 @@ class MeshUplinkDetector:
 # ====================================================================== #
 # Shared neighbour-scan helpers (wifi.neighbor_density + wifi.rogue_ap)
 # ====================================================================== #
+
+# ``stat/rogueap`` reports a neighbour's strength two ways, and only one of them
+# is dBm. ``signal`` is the real RSSI (negative). ``rssi`` is the driver's
+# 0-based quality index above the noise floor (positive, ~2..50 in practice),
+# exactly as documented on the mesh-uplink fields in ``ingest/unifi/models.py``.
+# Both neighbour detectors compare against a ``*_rssi_floor_dbm`` threshold, so
+# feeding them the index made every ``rssi <= -75`` test false and the
+# "strong enough to matter" filter a no-op: every audible BSS qualified, and a
+# quiet suburb reported hundreds of "neighbouring networks". Convert once here,
+# in the shared decoder, so the two detectors cannot disagree.
+#
+# The offset is the driver's noise-floor reference. -95 dBm is the Atheros/QCA
+# convention UniFi APs report against, and it is tunable like every other number
+# in this module: ``noise_floor_dbm`` under ``wifi.neighbor_density``. It is read
+# from that one key even though both detectors use it, because it describes the
+# *scan*, not either detector's policy, and the two must not be able to disagree
+# about what a given index means.
+_ROGUE_NOISE_FLOOR_DBM = -95
+
+# A negative number alone does not prove a field is dBm. Drivers use small
+# negative sentinels for "no reading" -- this module already carries ``or -127.0``
+# fallbacks for exactly that -- and a -1 accepted verbatim would read as an
+# absurdly strong neighbour that clears every ``rssi_floor_dbm`` and silently
+# inflates the qualifying count. A real neighbour sighting lands between these
+# lines, so anything outside them is junk to be ignored, not converted.
+_PLAUSIBLE_DBM_MAX = -20
+_PLAUSIBLE_DBM_MIN = -120
+
+
+def _plausible_dbm(value: Optional[int]) -> Optional[int]:
+    """``value`` if it could be a real dBm sighting, else ``None``."""
+    if value is None or not (_PLAUSIBLE_DBM_MIN <= value <= _PLAUSIBLE_DBM_MAX):
+        return None
+    return value
+
+
+def _neighbor_rssi_dbm(
+    meta: dict[str, Any], noise_floor: int = _ROGUE_NOISE_FLOOR_DBM
+) -> Optional[int]:
+    """Neighbour strength in dBm, whichever way the scan reported it.
+
+    Prefers ``signal`` (already dBm, and what newer polls persist), but only when
+    it is plausibly a real sighting: a positive or sentinel value is ignored in
+    favour of the index rather than trusted into a nonsense dBm. Falls back to
+    the quality index offset by ``noise_floor``, which is what rows collected
+    before ``signal`` was captured carry. An index that is already a plausible
+    dBm is passed through untouched, so re-running over mixed-vintage rows is
+    safe; one that is negative but implausible is junk and drops out.
+
+    Returns ``None`` when the scan reported neither field usably, which the
+    callers treat as unplaceable and skip. An index of exactly 0 is a real
+    reading at the noise floor, not a missing one, so it converts.
+    """
+    signal = _plausible_dbm(_as_int(meta.get("signal")))
+    if signal is not None:
+        return signal
+    index = _as_int(meta.get("rssi"))
+    if index is None:
+        return None
+    if index < 0:
+        return _plausible_dbm(index)
+    return index + noise_floor
+
+
 def _neighbor_rows(ctx: Any) -> list[dict[str, Any]]:
     """Decode the ``rogue_bss`` inventory rows into judged neighbour dicts.
 
@@ -1875,7 +1939,13 @@ def _neighbor_rows(ctx: Any) -> list[dict[str, Any]]:
     poll) is parsed here; the normalized band folds the reported code with a
     channel-number fallback. Both neighbour detectors read the inventory through
     this one decoder so they never disagree about what the scan said.
+
+    The emitted ``rssi`` is **dBm**, normalized by :func:`_neighbor_rssi_dbm`.
+    Callers compare it to ``*_rssi_floor_dbm`` thresholds directly.
     """
+    noise_floor = int(
+        ctx.threshold(KEY_NEIGHBOR_DENSITY, "noise_floor_dbm", _ROGUE_NOISE_FLOOR_DBM)
+    )
     rows = ctx.repo.list_entities(ROGUE_BSS_TYPE, site_id=ctx.site_id)
     out: list[dict[str, Any]] = []
     for row in rows:
@@ -1902,7 +1972,7 @@ def _neighbor_rows(ctx: Any) -> list[dict[str, Any]]:
                 if isinstance(channels, list)
                 else None,
                 "band": _norm_rogue_band(meta.get("band"), channel),
-                "rssi": _as_int(meta.get("rssi")),
+                "rssi": _neighbor_rssi_dbm(meta, noise_floor),
                 "security": meta.get("security"),
                 "seen_by_ap": meta.get("seen_by_ap"),
                 "is_rogue": meta.get("is_rogue"),

--- a/netadmin/ingest/collector.py
+++ b/netadmin/ingest/collector.py
@@ -391,6 +391,7 @@ class Collector:
                         "channel": r.channel,
                         "channels": channels or None,
                         "rssi": r.rssi,
+                        "signal": r.signal,
                         "band": r.band,
                         "security": r.security,
                         "is_rogue": r.is_rogue,

--- a/netadmin/ingest/unifi/models.py
+++ b/netadmin/ingest/unifi/models.py
@@ -298,7 +298,8 @@ class RogueAp(_Base):
     bssid: Optional[str] = None
     essid: Optional[str] = None
     channel: Optional[int] = None
-    rssi: Optional[int] = None
+    rssi: Optional[int] = None  # 0-based signal-quality index, NOT dBm
+    signal: Optional[int] = None  # RSSI in dBm (negative); absent on older polls
     band: Optional[str] = None
     security: Optional[str] = None
     is_rogue: Optional[bool] = None

--- a/tests/netadmin/detect/detectors/test_wifi.py
+++ b/tests/netadmin/detect/detectors/test_wifi.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Optional
 
+import pytest
+
 from netadmin.detect.context import DetectorContext
 from netadmin.detect.detectors.wifi import (
     KEY_AIRTIME_SATURATION,
@@ -40,6 +42,7 @@ from netadmin.detect.detectors.wifi import (
     RogueApDetector,
     StickyClientDetector,
     TxPowerLoudDetector,
+    _neighbor_rssi_dbm,
 )
 from netadmin.detect.engine import UNKNOWN, DetectorResult
 from netadmin.domain.entities import Entity
@@ -1238,6 +1241,7 @@ def mk_rogue(
     *,
     channel: int,
     rssi: int,
+    signal: Optional[int] = None,
     band: Optional[str] = None,
     essid: str = "Neighbor",
     first_seen: Optional[int] = None,
@@ -1258,6 +1262,8 @@ def mk_rogue(
     hopping neighbour.
     """
     meta: dict = {"channel": channel, "rssi": rssi, "is_rogue": is_rogue, "seen_by_ap": seen_by_ap}
+    if signal is not None:
+        meta["signal"] = signal
     if band is not None:
         meta["band"] = band
     if is_ubnt is not None:
@@ -1386,6 +1392,101 @@ def test_neighbor_density_floor_is_tunable(repo: Repository) -> None:
     findings = NeighborDensityDetector().evaluate(_ctx(repo, settings=settings))
     assert len(findings) == 1
     assert findings[0].evidence["qualifying_count"] == 2
+
+
+@pytest.mark.parametrize(
+    "meta,expected",
+    [
+        ({"rssi": 9}, -86),  # bare quality index: 9 above a -95 dBm floor
+        ({"rssi": 49}, -46),  # the loudest index seen on a real store
+        ({"rssi": 0}, -95),  # a real reading AT the floor, not a missing one
+        ({"rssi": -72}, -72),  # already dBm: passed through, re-run safe
+        ({"signal": -88, "rssi": 40}, -88),  # signal is dBm and wins
+        ({"signal": -88}, -88),  # signal alone
+        ({"signal": 40, "rssi": 9}, -86),  # malformed positive signal: ignored
+        ({"signal": 0, "rssi": 9}, -86),  # 0 is not a plausible dBm: ignored
+        ({}, None),  # neither field: unplaceable
+        ({"rssi": None, "signal": None}, None),
+        ({"rssi": "notanumber"}, None),
+        # A small-negative sentinel is not a -1 dBm neighbour standing in the
+        # room. Reject it, or it clears every floor and inflates the count.
+        ({"signal": -1, "rssi": 9}, -86),  # sentinel ignored, index used
+        ({"signal": -1}, None),  # sentinel with nothing to fall back to
+        ({"rssi": -2}, None),  # corrupted index, not a -2 dBm sighting
+        ({"signal": -400, "rssi": 9}, -86),  # below any real noise floor
+    ],
+)
+def test_neighbor_rssi_dbm_normalizes_every_shape_the_scan_can_report(meta, expected) -> None:
+    """The scan's two strength fields, and the junk either can arrive as."""
+    assert _neighbor_rssi_dbm(meta) == expected
+
+
+def test_neighbor_rssi_dbm_honours_a_tuned_noise_floor() -> None:
+    """A driver referenced to a different floor is correctable, not hardcoded."""
+    assert _neighbor_rssi_dbm({"rssi": 9}, -90) == -81
+    assert _neighbor_rssi_dbm({"signal": -88}, -90) == -88  # dBm ignores the floor
+
+
+def test_neighbor_density_noise_floor_is_tunable_end_to_end(repo: Repository) -> None:
+    """The threshold reaches the decoder, not just the helper's default arg."""
+    seed_cov(repo)
+    _our_5ghz_radio(repo, channel=36)
+    _neighbors_on_36(repo, 5, rssi=22)  # -73 dBm by default: over the -75 floor
+    assert len(NeighborDensityDetector().evaluate(_ctx(repo))) == 1
+
+    # Same scan, a floor 10 dB lower: -83 dBm, now under the -75 line.
+    settings = _settings(KEY_NEIGHBOR_DENSITY, noise_floor_dbm=-105)
+    assert NeighborDensityDetector().evaluate(_ctx(repo, settings=settings)) == []
+
+
+def test_neighbor_density_reads_the_quality_index_as_dbm_not_as_a_raw_number(
+    repo: Repository,
+) -> None:
+    """A scan that reports the 0-based index must not sail past the dBm floor.
+
+    ``stat/rogueap`` reports strength as a positive quality index above the noise
+    floor. Compared raw against ``rssi_floor_dbm`` (-75) every neighbour passed,
+    because a positive number is never <= -75, and the filter became a no-op:
+    real sites reported hundreds of "neighbouring networks" that were in fact
+    barely audible. Index 9 is -86 dBm, well under the floor, so this is a clear.
+    """
+    seed_cov(repo)
+    _our_5ghz_radio(repo, channel=36)
+    _neighbors_on_36(repo, 6, rssi=9)
+    assert NeighborDensityDetector().evaluate(_ctx(repo)) == []
+
+
+def test_neighbor_density_counts_a_quality_index_that_is_genuinely_strong(
+    repo: Repository,
+) -> None:
+    """The conversion must not swing the other way and mute real neighbours."""
+    seed_cov(repo)
+    _our_5ghz_radio(repo, channel=36)
+    _neighbors_on_36(repo, 4, rssi=40)  # -55 dBm, comfortably over the floor
+    findings = NeighborDensityDetector().evaluate(_ctx(repo))
+    assert len(findings) == 1
+    assert findings[0].evidence["qualifying_count"] == 4
+    assert findings[0].evidence["top_offenders"][0]["rssi_dbm"] == -55
+
+
+def test_neighbor_density_prefers_the_signal_field_when_the_poll_captured_it(
+    repo: Repository,
+) -> None:
+    """``signal`` is already dBm, so it wins over the index it sits beside."""
+    seed_cov(repo)
+    _our_5ghz_radio(repo, channel=36)
+    for i in range(4):
+        mk_rogue(
+            repo,
+            f"de:ad:be:ef:20:{i:02x}",
+            channel=36,
+            rssi=40,  # index alone would read as -55 dBm
+            signal=-88,  # the controller's truth: far too weak to matter
+            band="na",
+            essid=f"Far-{i}",
+            scan_ts=[NOW - 86_400, NOW],
+        )
+    assert NeighborDensityDetector().evaluate(_ctx(repo)) == []
 
 
 def test_neighbor_density_p2_only_when_an_overlapped_radio_is_congested(repo: Repository) -> None:


### PR DESCRIPTION
## The bug

`stat/rogueap` reports neighbour strength two ways:

- `signal` is the real RSSI in dBm (negative)
- `rssi` is the driver's 0-based quality index above the noise floor (positive, roughly 2..50 in practice)

`ingest/unifi/models.py` already documents exactly that distinction on the mesh-uplink fields, but `RogueAp` dropped `signal` entirely and the shared neighbour decoder passed the index straight through as `"rssi"`.

Both `wifi.neighbor_density` and `wifi.rogue_ap` then compare that value against a `*_rssi_floor_dbm` threshold. A positive number is never `<= -75`, so the "strong enough to matter" filter never excluded anything and every audible BSS qualified.

On my own store that reported **258 of 265** scanned networks as crowding the 2.4 GHz channels, in a neighbourhood nowhere near that dense. All 619 neighbour rows carried positive values, range 2 to 49, not one negative. The count above the real -75 dBm line is **14**.

## The fix

Convert once in `_neighbor_rows`, the shared decoder both detectors already read through, so the two cannot disagree about what the scan said.

- Prefer `signal` when the poll captured it
- Fall back to the index offset by the noise floor for rows collected before it did
- The offset is tunable as `noise_floor_dbm` under `wifi.neighbor_density`, read from that one key by the shared decoder because it describes the *scan*, not either detector's policy
- Capture and persist `signal` on `RogueAp` so new scans carry exact dBm rather than an offset estimate

Sign alone does not prove a field is dBm. Drivers use small negative sentinels for "no reading", and this module already carries `or -127.0` fallbacks for that case. A `-1` taken verbatim would read as an absurdly strong neighbour that clears every floor and silently inflates the count, so both branches require a plausible sighting (-120..-20 dBm) and treat anything else as junk.

## Verification

Full suite: **2002 passed, 1 skipped**.

New tests cover the index reading as dBm, a genuinely strong index still counting, `signal` winning when both are present, `noise_floor_dbm` reaching the decoder end to end, and the sentinel cases (`-1`, `-400`, a negative index) being rejected rather than trusted.

Replayed against a real 619-row store, the 2.4 GHz finding goes from 258 qualifying to 14:

| Stronger than | Count |
|---|---|
| -65 dBm | 3 |
| -70 dBm | 5 |
| **-75 dBm (the floor)** | **14** |
| -80 dBm | 28 |

The 5 GHz finding falls below `density_min_count` and clears. Top-offender ordering is unchanged and the values are now real dBm.

## Known gap, not addressed here

A finding's `rssi_dbm` evidence does not say whether it came from a measured `signal` or an offset index. On a mixed-vintage store those are indistinguishable, and the estimated ones move if `noise_floor_dbm` is retuned. An `rssi_source` field would fix it; happy to add if you want it in this PR.